### PR TITLE
Scan Flow fails due size limit exceed on Static Code Analysis/Violation objects

### DIFF
--- a/force-app/main/default/flows/ClaytonDiffScan.flow-meta.xml
+++ b/force-app/main/default/flows/ClaytonDiffScan.flow-meta.xml
@@ -3,13 +3,16 @@
     <actionCalls>
         <name>Get_Scan_Diff</name>
         <label>Get Scan Diff</label>
-        <locationX>578</locationX>
+        <locationX>776</locationX>
         <locationY>878</locationY>
         <actionName>clayton::ClaytonPullRequestAPI.getPullRequestDiffBranches</actionName>
         <actionType>externalService</actionType>
         <connector>
             <targetReference>Is_Scan_Diff_Completed</targetReference>
         </connector>
+        <faultConnector>
+            <targetReference>Copy_1_of_Copy_1_of_Update_Clayton_Scan_Job_Failed</targetReference>
+        </faultConnector>
         <flowTransactionModel>CurrentTransaction</flowTransactionModel>
         <inputParameters>
             <name>account</name>
@@ -34,7 +37,7 @@
     <actionCalls>
         <name>Get_Scan_Diff_Issues</name>
         <label>Get Scan Diff Issues</label>
-        <locationX>226</locationX>
+        <locationX>358</locationX>
         <locationY>1118</locationY>
         <actionName>clayton::ClaytonPullRequestAPI.getPullRequestDiffBranchesIssues</actionName>
         <actionType>externalService</actionType>
@@ -81,6 +84,9 @@
         <connector>
             <targetReference>Add_issues</targetReference>
         </connector>
+        <faultConnector>
+            <targetReference>Copy_1_of_Copy_1_of_Copy_1_of_Update_Clayton_Scan_Job_Failed</targetReference>
+        </faultConnector>
         <flowTransactionModel>CurrentTransaction</flowTransactionModel>
         <inputParameters>
             <name>account</name>
@@ -117,13 +123,16 @@
     <actionCalls>
         <name>Scan_By_Diff</name>
         <label>Scan By Diff</label>
-        <locationX>886</locationX>
+        <locationX>1249</locationX>
         <locationY>398</locationY>
         <actionName>clayton::ClaytonScanAPI.scanByDiff</actionName>
         <actionType>externalService</actionType>
         <connector>
             <targetReference>Create_Clayton_Scan_Job</targetReference>
         </connector>
+        <faultConnector>
+            <targetReference>Copy_1_of_Update_Clayton_Scan_Job_Failed</targetReference>
+        </faultConnector>
         <flowTransactionModel>CurrentTransaction</flowTransactionModel>
         <inputParameters>
             <name>account</name>
@@ -165,7 +174,7 @@
     <assignments>
         <name>Assign_Ids</name>
         <label>Assign Ids</label>
-        <locationX>886</locationX>
+        <locationX>1249</locationX>
         <locationY>638</locationY>
         <assignmentItems>
             <assignToReference>ClaytonScanId</assignToReference>
@@ -181,7 +190,7 @@
     <assignments>
         <name>Assign_ScanByDiff_Input</name>
         <label>Assign ScanByDiff Input</label>
-        <locationX>886</locationX>
+        <locationX>1249</locationX>
         <locationY>278</locationY>
         <assignmentItems>
             <assignToReference>ScanByDiffInput.branchx5fsource</assignToReference>
@@ -234,7 +243,7 @@
     <decisions>
         <name>Check_Processed_Pages</name>
         <label>Check Processed Pages</label>
-        <locationX>226</locationX>
+        <locationX>358</locationX>
         <locationY>1238</locationY>
         <defaultConnector>
             <targetReference>Read_Clayton_Static_Code_Analysis_Record_Type</targetReference>
@@ -259,7 +268,7 @@
     <decisions>
         <name>Is_Scan_Diff_Completed</name>
         <label>Is Scan Diff Completed</label>
-        <locationX>578</locationX>
+        <locationX>776</locationX>
         <locationY>998</locationY>
         <defaultConnector>
             <targetReference>WaitScanCompleted</targetReference>
@@ -292,10 +301,20 @@
         <expression>{!$Flow.CurrentDateTime} + {!WaitingTimeMinutes} / (24 * 60)</expression>
     </formulas>
     <formulas>
+        <name>IssueMessage</name>
+        <dataType>String</dataType>
+        <expression>LEFT({!Create_Static_Code_Analysis_Violations.commentx5fbody}, 255)</expression>
+    </formulas>
+    <formulas>
         <name>IssuePriority</name>
         <dataType>Number</dataType>
         <expression>CASE({!Create_Static_Code_Analysis_Violations.severity}, &apos;CRITICAL&apos;, 1, &apos;ERROR&apos;, 2,3)</expression>
         <scale>0</scale>
+    </formulas>
+    <formulas>
+        <name>IssueRule</name>
+        <dataType>String</dataType>
+        <expression>LEFT({!Create_Static_Code_Analysis_Violations.name}, 255)</expression>
     </formulas>
     <formulas>
         <name>IssueSeverity</name>
@@ -319,7 +338,7 @@
     <loops>
         <name>Create_Static_Code_Analysis_Violations</name>
         <label>Create Static Code Analysis Violations</label>
-        <locationX>402</locationX>
+        <locationX>666</locationX>
         <locationY>1598</locationY>
         <collectionReference>TotalIssues</collectionReference>
         <iterationOrder>Asc</iterationOrder>
@@ -352,7 +371,7 @@
     <recordCreates>
         <name>Create_Clayton_Scan_Job</name>
         <label>Create Clayton Scan Job</label>
-        <locationX>886</locationX>
+        <locationX>1249</locationX>
         <locationY>518</locationY>
         <assignRecordIdToReference>CopadoResultId</assignRecordIdToReference>
         <connector>
@@ -399,7 +418,7 @@
     <recordCreates>
         <name>Create_Static_Code_Analysis_Result</name>
         <label>Create Static Code Analysis Result</label>
-        <locationX>402</locationX>
+        <locationX>666</locationX>
         <locationY>1478</locationY>
         <connector>
             <targetReference>Create_Static_Code_Analysis_Violations</targetReference>
@@ -422,7 +441,7 @@
     <recordCreates>
         <name>Create_Static_Code_Analysis_Violation</name>
         <label>Create Static Code Analysis Violation</label>
-        <locationX>490</locationX>
+        <locationX>754</locationX>
         <locationY>1718</locationY>
         <connector>
             <targetReference>Create_Static_Code_Analysis_Violations</targetReference>
@@ -448,7 +467,7 @@
         <inputAssignments>
             <field>copado__Message__c</field>
             <value>
-                <elementReference>Create_Static_Code_Analysis_Violations.commentx5fbody</elementReference>
+                <elementReference>IssueMessage</elementReference>
             </value>
         </inputAssignments>
         <inputAssignments>
@@ -460,7 +479,7 @@
         <inputAssignments>
             <field>copado__Rule__c</field>
             <value>
-                <elementReference>Create_Static_Code_Analysis_Violations.name</elementReference>
+                <elementReference>IssueRule</elementReference>
             </value>
         </inputAssignments>
         <inputAssignments>
@@ -481,7 +500,7 @@
     <recordLookups>
         <name>Read_Clayton_Static_Code_Analysis_Record_Type</name>
         <label>Read Clayton Static Code Analysis Record Type</label>
-        <locationX>402</locationX>
+        <locationX>666</locationX>
         <locationY>1358</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -502,9 +521,72 @@
         </outputAssignments>
     </recordLookups>
     <recordUpdates>
+        <name>Copy_1_of_Copy_1_of_Copy_1_of_Update_Clayton_Scan_Job_Failed</name>
+        <label>Copy 1 of Copy 1 of Copy 1 of Update Clayton Scan Job Failed</label>
+        <locationX>314</locationX>
+        <locationY>1478</locationY>
+        <filterLogic>and</filterLogic>
+        <filters>
+            <field>Id</field>
+            <operator>EqualTo</operator>
+            <value>
+                <elementReference>CopadoResultId</elementReference>
+            </value>
+        </filters>
+        <inputAssignments>
+            <field>copado__Status__c</field>
+            <value>
+                <stringValue>Failed</stringValue>
+            </value>
+        </inputAssignments>
+        <object>copado__Result__c</object>
+    </recordUpdates>
+    <recordUpdates>
+        <name>Copy_1_of_Copy_1_of_Update_Clayton_Scan_Job_Failed</name>
+        <label>Copy 1 of Copy 1 of Update Clayton Scan Job Failed</label>
+        <locationX>1458</locationX>
+        <locationY>998</locationY>
+        <filterLogic>and</filterLogic>
+        <filters>
+            <field>Id</field>
+            <operator>EqualTo</operator>
+            <value>
+                <elementReference>CopadoResultId</elementReference>
+            </value>
+        </filters>
+        <inputAssignments>
+            <field>copado__Status__c</field>
+            <value>
+                <stringValue>Failed</stringValue>
+            </value>
+        </inputAssignments>
+        <object>copado__Result__c</object>
+    </recordUpdates>
+    <recordUpdates>
+        <name>Copy_1_of_Update_Clayton_Scan_Job_Failed</name>
+        <label>Copy 1 of Update Clayton Scan Job Failed</label>
+        <locationX>1986</locationX>
+        <locationY>518</locationY>
+        <filterLogic>and</filterLogic>
+        <filters>
+            <field>Id</field>
+            <operator>EqualTo</operator>
+            <value>
+                <elementReference>CopadoResultId</elementReference>
+            </value>
+        </filters>
+        <inputAssignments>
+            <field>copado__Status__c</field>
+            <value>
+                <stringValue>Failed</stringValue>
+            </value>
+        </inputAssignments>
+        <object>copado__Result__c</object>
+    </recordUpdates>
+    <recordUpdates>
         <name>Update_Clayton_Scan_Job</name>
         <label>Update Clayton Scan Job</label>
-        <locationX>402</locationX>
+        <locationX>666</locationX>
         <locationY>1934</locationY>
         <filterLogic>and</filterLogic>
         <filters>
@@ -543,7 +625,7 @@
     <recordUpdates>
         <name>Update_Clayton_Scan_Job_Failed</name>
         <label>Update Clayton Scan Job Failed</label>
-        <locationX>666</locationX>
+        <locationX>930</locationX>
         <locationY>1238</locationY>
         <filterLogic>and</filterLogic>
         <filters>
@@ -562,7 +644,7 @@
         <object>copado__Result__c</object>
     </recordUpdates>
     <start>
-        <locationX>760</locationX>
+        <locationX>1123</locationX>
         <locationY>0</locationY>
         <connector>
             <targetReference>Initialise_Scan_Context</targetReference>
@@ -572,7 +654,7 @@
     <subflows>
         <name>Initialise_Scan_Context</name>
         <label>Initialise Scan Context</label>
-        <locationX>886</locationX>
+        <locationX>1249</locationX>
         <locationY>158</locationY>
         <connector>
             <targetReference>Assign_ScanByDiff_Input</targetReference>
@@ -687,7 +769,7 @@
     <waits>
         <name>WaitScanCompleted</name>
         <label>Wait Scan Completed</label>
-        <locationX>886</locationX>
+        <locationX>1249</locationX>
         <locationY>758</locationY>
         <defaultConnectorLabel>Default Path</defaultConnectorLabel>
         <waitEvents>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "path": "force-app",
             "default": true,
             "package": "Clayton for Copado",
-            "versionName": "Version 1.6.3",
-            "versionNumber": "1.6.3.NEXT",
+            "versionName": "Version 1.6.4",
+            "versionNumber": "1.6.4.NEXT",
             "dependencies": [
                 {
                     "package": "Copado Deployer@17.8.0.0"


### PR DESCRIPTION
# Description

[Copado Integration] - Scan Flow fails due size limit exceed on Static Code Analysis/Violation objects

## Asana tasks
- https://app.asana.com/0/1200113379311181/1203419633308509/f

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code builds clean without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated Clayton Copado Integration [Notion](https://www.notion.so/getclayton/Copado-Integration-bcf295ae4f5d4f68921e0dbb173fd191) page
