### PR TITLE
Ensure `ignore-scripts=true` in `.npmrc` for npm directories

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true


### PR DESCRIPTION

This PR was auto generated by script

### Why do we need this?
Supply chain attacks are an ongoing risk for us. Specifically, when installing packages we don't want to run any postinstall scripts.

The following Slack message has some deeper context -> https://gearsethq.slack.com/archives/C01F15WFJAU/p1758029881605319

The script has identified directories with a `package.json` that either have no `.npmrc` file or have one that does not include `ignore-scripts=true`. This PR addresses both cases.

### What does this PR change?
Ensures every directory containing a `package.json` has an `.npmrc` with `ignore-scripts=true`

### Files added
- `.npmrc`